### PR TITLE
Fixed flaky test by changing how events are compared to emitted events

### DIFF
--- a/.github/scripts/unit_tests_script.sh
+++ b/.github/scripts/unit_tests_script.sh
@@ -21,7 +21,10 @@ unset _JAVA_OPTIONS
 
 # Set MAVEN_OPTS for Surefire launcher.
 MAVEN_OPTS='-Xmx2500m' ${MVN} test -pl ${MAVEN_PROJECTS} \
-${MAVEN_SKIP} -Ddruid.generic.useDefaultValueForNull=${DRUID_USE_DEFAULT_VALUE_FOR_NULL}
+${MAVEN_SKIP} -Ddruid.generic.useDefaultValueForNull=${DRUID_USE_DEFAULT_VALUE_FOR_NULL} \
+-Dtest=org.apache.druid.java.util.emitter.core.EmitterTest#testBasicAuthenticationAndNewlineSeparating \
+edu.illinois:nondex-maven-plugin:2.1.1:nondex
+
 sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
 free -m
 ${MVN} -pl ${MAVEN_PROJECTS} jacoco:report

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,6 +25,17 @@ on:
         type: boolean
         default: true
         description: 'For SQL compatibility'
+  workflow_dispatch:
+    inputs:
+      jdk:
+        required: true
+        type: string
+        description: 'JDK version used to test Druid'
+      sql_compatibility:
+        required: false
+        type: boolean
+        default: true
+        description: 'For SQL compatibility'
 
 jobs:
 #  indexing_modules_test:


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Fixes #XXXX. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

The unit test EmitterTest.testBasicAuthenticationAndNewlineSeparating() has been identified as a flaky test by [idoft](https://github.com/TestingResearchIllinois/idoft)

This test will usually pass, but repeatedly running it will consistently, but sporadically, result in some failed tests.

This behavior can be caught by running the [nondex tool](https://github.com/TestingResearchIllinois/NonDex)

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

The failure results from the goHandler's request.getByteBufferData() method sometimes returning events in different orders, and sometimes the data being mixed up.

For example, sometimes `StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString();` will return:

```
{"feed":"test","metrics":{"value":1}}
{"feed":"test2","metrics":{"value":2}}
```

and sometimes

```
{"feed":"test2","metrics":{"value":2}}
{"feed":"test","metrics":{"value":1}}
```

and more often

```
{"metrics":{"value":2}, "feed":"test2"}
{"feed":"test","metrics":{"value":1}}
```

The previous method of comparing the value returned by the goHandler to the events emitted was to simply create a string from the events list and compare it directly to the the String formatted list. This has proven to be unreliable due to the above issue.

Pipeline demonstrating issue:
https://github.com/JaredDiCioccio/swe647druid/actions/runs/4507633919

### Proposed Fix


1. The current proposed fix is to convert these string values to a Map. Once all values are converted to a map, they can be compared directly using the .equals() method. This conversion essentially eliminates the dependency on order of emission as well as what order the stringified version of the map is in.
2. Increased number of times goHandler tries to go.

Pipeline demonstrating passing nondex tests:
https://github.com/JaredDiCioccio/swe647druid/actions/runs/4511948205

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: 

#### Fixed the bug 
#### Renamed the class ...
#### Added a forbidden-apis entry ...

-->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. 

#### Release note
-->
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `EmitterTest`
<hr>